### PR TITLE
Add gotify to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,62 @@ Configuration is done through environment variables. The following variables are
 
 More details can be found in the [config.env.example](config.env.example) file.
 
+## Notifications
+
+Notification(s) can be sent whenever a server is available. Either one or multiple notification services can be used.
+
+Supported notification services:
+- [Gotify](https://gotify.net/)
+- [OpsGenie](https://www.atlassian.com/software/opsgenie) via [Alerts API](https://docs.opsgenie.com/docs/alert-api)
+- [Telegram](https://telegram.org/) via [Bots API#sendMessage](https://core.telegram.org/bots/api#sendmessage)
+
+In order to use a notification service, it is recommended to set its environment variables in the config file, see [config.env.example](config.env.example).
+
+### Gotify
+
+In order to recieve notifications for Gotify, the appropriate environment variables must be set:
+
+- `GOTIFY_URL`: URL to use for Gotify notification service
+- `GOTIFY_TOKEN`: token to use for Gotify notification service
+- `GOTIFY_PRIORITY`: prority for Gotify notification service
+
+See [Gotify Push messages](https://gotify.net/docs/pushmsg) documentation for more information.
+
+### OpsGenie
+
+In order to recieve notifications for OpsGenie, the appropriate environment variables must be set:
+
+- `OPSGENIE_API_KEY`: API key to use OpsGenie notification service
+
+See [OpsGenie API key](https://support.atlassian.com/opsgenie/docs/api-key-management/) or [OpsGenie integration](https://support.atlassian.com/opsgenie/docs/create-a-default-api-integration/) for more information.
+
+Example with OpsGenie:
+```
+$ bin/check.sh --plan-code 24ska01
+> checking 24ska01 availability in all datacenters
+> checked  24ska01 available    in fr,gra,rbx,sbg
+> sending OpsGenie notification
+> sent    OpsGenie notification
+```
+
+### Telegram
+
+In order to recieve notifications for Telegram, the appropriate environment variables must be set:
+
+- `TELEGRAM_CHAT_ID`: chat ID to use Telegram notification service
+- `TELEGRAM_BOT_TOKEN`: bot token to use Telegram notification service
+
+See [Telegram bot creation guide](https://core.telegram.org/bots/features#creating-a-new-bot) or [this Gist](https://gist.github.com/nafiesl/4ad622f344cd1dc3bb1ecbe468ff9f8a#file-how_to_get_telegram_chat_id-md)
+
+Example with Telegram:
+```
+$ bin/check.sh --plan-code 24ska01
+> checking 24ska01 availability in all datacenters
+> checked  24ska01 available    in fr,gra,rbx,sbg
+> sending Telegram notification
+> sent    Telegram notification
+```
+
 ## Usage
 
 ```
@@ -135,62 +191,4 @@ Check availability of a specific server in all datacenters.
 $ bin/check.sh --plan-code 24ska01
 > checking 24ska01 availability in all datacenters
 > checked  24ska01 unavailable  in fr,gra,rbx,sbg
-```
-
-## Notifications
-
-Notification(s) can be sent whenever a server is available. Either one or multiple notification services can be used.
-
-Supported notification services:
-- [Gotify](https://gotify.net/)
-- [OpsGenie](https://www.atlassian.com/software/opsgenie) via [Alerts API](https://docs.opsgenie.com/docs/alert-api)
-- [Telegram](https://telegram.org/) via [Bots API#sendMessage](https://core.telegram.org/bots/api#sendmessage)
-
-In order to use a notification service, it is recommended to set its environment variables in the config file, see [config.env.example](config.env.example).
-
-### Gotify
-
-In order to recieve notifications for Gotify, the appropriate environment variables must be set:
-
-- `GOTIFY_URL`: URL to use for Gotify notification service
-- `GOTIFY_TOKEN`: token to use for Gotify notification service
-- `GOTIFY_PRIORITY`: prority for Gotify notification service
-
-See [Gotify Push messages](https://gotify.net/docs/pushmsg) documentation for more information.
-
-### OpsGenie
-
-In order to recieve notifications for OpsGenie, the appropriate environment variables must be set:
-
-- `OPSGENIE_API_KEY`: API key to use OpsGenie notification service
-
-See [OpsGenie API key](https://support.atlassian.com/opsgenie/docs/api-key-management/) or [OpsGenie integration](https://support.atlassian.com/opsgenie/docs/create-a-default-api-integration/) for more information.
-
-### Telegram
-
-In order to recieve notifications for Telegram, the appropriate environment variables must be set:
-
-- `TELEGRAM_CHAT_ID`: chat ID to use Telegram notification service
-- `TELEGRAM_BOT_TOKEN`: bot token to use Telegram notification service
-
-See [Telegram bot creation guide](https://core.telegram.org/bots/features#creating-a-new-bot) or [this Gist](https://gist.github.com/nafiesl/4ad622f344cd1dc3bb1ecbe468ff9f8a#file-how_to_get_telegram_chat_id-md)
-
-### Examples
-
-Example with OpsGenie:
-```
-$ bin/check.sh --plan-code 24ska01
-> checking 24ska01 availability in all datacenters
-> checked  24ska01 available    in fr,gra,rbx,sbg
-> sending OpsGenie notification
-> sent    OpsGenie notification
-```
-
-Example with Telegram:
-```
-$ bin/check.sh --plan-code 24ska01
-> checking 24ska01 availability in all datacenters
-> checked  24ska01 available    in fr,gra,rbx,sbg
-> sending Telegram notification
-> sent    Telegram notification
 ```

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ In order to recieve notifications for Gotify, the appropriate environment variab
 - `GOTIFY_TOKEN`: token to use for Gotify notification service
 - `GOTIFY_PRIORITY`: prority for Gotify notification service
 
+See [Gotify Push messages](https://gotify.net/docs/pushmsg) documentation for more information.
+
 ### OpsGenie
 
 In order to recieve notifications for OpsGenie, the appropriate environment variables must be set:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Supported notification services:
 - [OpsGenie](https://www.atlassian.com/software/opsgenie) via [Alerts API](https://docs.opsgenie.com/docs/alert-api)
 - [Telegram](https://telegram.org/) via [Bots API#sendMessage](https://core.telegram.org/bots/api#sendmessage)
 
-It is recommended to set those values in the config file, see [config.env.example](config.env.example).
+In order to use a notification service, it is recommended to set its environment variables in the config file, see [config.env.example](config.env.example).
 
 ### Gotify
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ Configuration is done through environment variables. The following variables are
 - `PLAN_CODE`: plan code to check availability for (e.g. `24ska01`)
 - `DATACENTERS`: comma-separated list of datacenters to check availability in (e.g. `fr,gra,rbx,sbg`)
 - `ENDPOINT`: OVH API endpoint to use (e.g. `ovh-eu`)
-- `OPSGENIE_API_KEY`: API key to use OpsGenie notification service
-- `TELEGRAM_CHAT_ID`: chat ID to use Telegram notification service
-- `TELEGRAM_BOT_TOKEN`: bot token to use Telegram notification service
 - `HEALTHCHECKS_IO_UUID`: UUID for healthchecks.io to ping after successful run
 
 More details can be found in the [config.env.example](config.env.example) file.
@@ -89,6 +86,9 @@ Arguments
   Command line arguments take precedence over environment variables
 
 Environment variables
+    GOTIFY_URL            URL to use for Gotify notification service
+    GOTIFY_TOKEN          token to use for Gotify notification service
+    GOTIFY_PRIORITY       prority for Gotify notification service
     OPSGENIE_API_KEY      API key for OpsGenie to receive notifications
     TELEGRAM_BOT_TOKEN    Bot token for Telegram to receive notifications
     TELEGRAM_CHAT_ID      Chat ID for Telegram to receive notifications
@@ -142,16 +142,36 @@ $ bin/check.sh --plan-code 24ska01
 Notification(s) can be sent whenever a server is available. Either one or multiple notification services can be used.
 
 Supported notification services:
+- [Gotify](https://gotify.net/)
 - [OpsGenie](https://www.atlassian.com/software/opsgenie) via [Alerts API](https://docs.opsgenie.com/docs/alert-api)
 - [Telegram](https://telegram.org/) via [Bots API#sendMessage](https://core.telegram.org/bots/api#sendmessage)
 
-In order to receive notifications the appropriate environment variables must be set:
+It is recommended to set those values in the config file, see [config.env.example](config.env.example).
 
-- `OPSGENIE_API_KEY`: required to use OpsGenie notifications, see [OpsGenie API key](https://support.atlassian.com/opsgenie/docs/api-key-management/) or [OpsGenie integration](https://support.atlassian.com/opsgenie/docs/create-a-default-api-integration/)
-- `TELEGRAM_CHAT_ID`: required to use Telegram notifications, see [Telegram bot creation guide](https://core.telegram.org/bots/features#creating-a-new-bot) or [this Gist](https://gist.github.com/nafiesl/4ad622f344cd1dc3bb1ecbe468ff9f8a#file-how_to_get_telegram_chat_id-md)
-- `TELEGRAM_BOT_TOKEN`: required to use Telegram as notifications
+### Gotify
 
-It is recommended to set those values in the config file, see [config.env.example](config.env.exampl).
+In order to recieve notifications for Gotify, the appropriate environment variables must be set:
+
+- `GOTIFY_URL`: URL to use for Gotify notification service
+- `GOTIFY_TOKEN`: token to use for Gotify notification service
+- `GOTIFY_PRIORITY`: prority for Gotify notification service
+
+### OpsGenie
+
+In order to recieve notifications for OpsGenie, the appropriate environment variables must be set:
+
+- `OPSGENIE_API_KEY`: API key to use OpsGenie notification service
+
+See [OpsGenie API key](https://support.atlassian.com/opsgenie/docs/api-key-management/) or [OpsGenie integration](https://support.atlassian.com/opsgenie/docs/create-a-default-api-integration/) for more information.
+
+### Telegram
+
+In order to recieve notifications for Telegram, the appropriate environment variables must be set:
+
+- `TELEGRAM_CHAT_ID`: chat ID to use Telegram notification service
+- `TELEGRAM_BOT_TOKEN`: bot token to use Telegram notification service
+
+See [Telegram bot creation guide](https://core.telegram.org/bots/features#creating-a-new-bot) or [this Gist](https://gist.github.com/nafiesl/4ad622f344cd1dc3bb1ecbe468ff9f8a#file-how_to_get_telegram_chat_id-md)
 
 ### Examples
 

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -35,6 +35,9 @@ usage() {
   echo_stderr "  Command line arguments take precedence over environment variables"
   echo_stderr
   echo_stderr "Environment variables"
+  echo_stderr "    GOTIFY_URL            URL to use for Gotify notification service"
+  echo_stderr "    GOTIFY_TOKEN          token to use for Gotify notification service"
+  echo_stderr "    GOTIFY_PRIORITY       prority for Gotify notification service"
   echo_stderr "    OPSGENIE_API_KEY      API key for OpsGenie to receive notifications"
   echo_stderr "    TELEGRAM_BOT_TOKEN    Bot token for Telegram to receive notifications"
   echo_stderr "    TELEGRAM_CHAT_ID      Chat ID for Telegram to receive notifications"


### PR DESCRIPTION
I was thinking of adding support for another notification service, Discord, and I decided to clean up the README a bit to make it more expandable to more services in the future. I also added gotify to the README as well.

* Removed notification related ENVs from the Configuration section since they have their own Notification section below.
* Added Gotify to the supported Notification services
* Split out the Notification envs into a separate heading per service
* Added Gotify ENVs to usage