### PR TITLE
Fix column invalid option -- 'C'

### DIFF
--- a/bin/list.sh
+++ b/bin/list.sh
@@ -135,7 +135,7 @@ main() {
   echo "$DATA" | \
     $JQ_BIN -r '.plans[] '"$category_filter"' | [ .planCode, .blobs.commercial.range, .invoiceName, (.pricings[] | select(.phase == 1) | select(.mode == "default") | .price/100000000) ] | @tsv' | \
     sort -k2,2 -k4n,4 -b -t $'\t' | \
-    column -s $'\t' -t -C "name=PlanCode" -C "name=Category" -C "name=Name" -C "name=Price ($CURRENCY)" -o '    '
+    column -s $'\t' -t -N "PlanCode,Category,Name,Price ($CURRENCY)" -o '    '
 }
 
 main "$@"


### PR DESCRIPTION
Fixes #3

This PR fixes an issue with `column` command which was failing with due to invalid option `-C`.
This option was introduced in `column` v2.39 https://github.com/util-linux/util-linux/blob/stable/v2.39/text-utils/column.c#L752