### PR TITLE
Fix order script to be compatible with curl below 8.3.0

### DIFF
--- a/bin/order.sh
+++ b/bin/order.sh
@@ -74,8 +74,8 @@ request() {
     --header "Accept: application/json"\
     --header "Content-Type: application/json" \
     --data "${data}" \
-    -w '\n%output{'$HTTP_CODE_FILE'}%{http_code}' \
-    "$@"
+    -w '%{stderr}%{http_code}' \
+    "$@" 2>$HTTP_CODE_FILE
   set +x
 
   http_code=$(cat "$HTTP_CODE_FILE")


### PR DESCRIPTION
Fixes https://github.com/TheoBrigitte/kimsufi-notifier/issues/14

There is an issue in the way the http code from curl is captured, the `%output{}` operator is only available from curl 8.3.0.
This PR changes this to use standard shell redirection to capture the http code.